### PR TITLE
Fix: mise à jour du fichier de configuration openapi versionné

### DIFF
--- a/App/Controllers/Api.php
+++ b/App/Controllers/Api.php
@@ -6,6 +6,7 @@ use App\Models\Articles;
 use App\Models\Cities;
 use Core\Controller;
 use Exception;
+use OpenApi\Annotations as OA;
 
 
 /**

--- a/public/swagger-ui/swagger.yaml
+++ b/public/swagger-ui/swagger.yaml
@@ -16,7 +16,7 @@ paths:
               schema:
                 type: array
                 items:
-                  properties: { id: { type: integer }, name: { type: string }, description: { type: string }, price: { type: number, format: float } }
+                  properties: { id: { type: integer }, name: { type: string }, description: { type: string }, published_date: { type: string }, user_id: { type: integer }, views: { type: integer }, picture: { type: string }, ville_id: { type: integer } }
                   type: object
   /cities:
     get:


### PR DESCRIPTION
## Description

Comme le fichier de config a été versionné (on ne devrait peut-être pas d'ailleurs qu'il est régénéré), je l'ai mis à jour avec les bons attributs pour les articles.